### PR TITLE
Vlad expansion

### DIFF
--- a/inc/lexing.h
+++ b/inc/lexing.h
@@ -28,6 +28,7 @@ typedef struct s_token
 	char			*value;
 	int				len;
 	t_token_type	type;
+	bool			ambiguous;
 	struct s_token	*next;
 }				t_token;
 

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -13,6 +13,7 @@
 # include <limits.h>			//FILE_MAX
 # include <sys/wait.h>
 # include <sys/stat.h>
+# include <stdbool.h>			//bool
 # include "../lib/libft/inc/libft.h"
 # include "signals.h"
 # include "lexing.h"
@@ -80,7 +81,7 @@ void	replace_content_of_token(t_token *current, char *new_str);
 int		there_is_quote_state_change(t_quotes_helper quotes);
 
 //quote handler
-void	expand_remove_quotes(t_minishell *mshell, t_token *tokens);
+void	expand_remove_quotes(t_minishell *mshell, t_input *input);
 
 //quote utils
 int		is_valid_expandable(t_quotes_helper quotes, char *input_str);
@@ -91,7 +92,7 @@ int		is_pid_expansion(t_quotes_helper quotes, char *input_str);
 
 //expansion
 size_t	expand_pid(t_minishell *mshell, int fd, char **new_str);
-size_t	expand_content(t_minishell *mshell, char *str, int fd, char **new_str);
+size_t	expand_content(t_minishell *mshell, t_token *current, char *str, int fd, char **new_str);
 size_t	expand_exitcode_value(t_minishell *mshell, int fd, char **new_str);
 void	write_or_add_to_str(t_minishell *mshell, int fd, char **new_str, char *str_pid);
 int		skip_to_start_of_expandable(char *env_row);

--- a/src/3.tokens/create_tokens.c
+++ b/src/3.tokens/create_tokens.c
@@ -12,6 +12,7 @@ static t_token	*init_token(t_minishell *mshell, \
 	new_token->len = len;
 	new_token->type = type;
 	new_token->next = NULL;
+	new_token->ambiguous = 0;
 	input->index += len;
 	return (new_token);
 }
@@ -28,6 +29,7 @@ static t_token	*init_token_word(t_minishell *mshell, \
 	new_token->len = ft_strlen(word);
 	new_token->type = type;
 	new_token->next = NULL;
+	new_token->ambiguous = 0;
 	return (new_token);
 }
 

--- a/src/4.heredoc/heredoc_tmp_files.c
+++ b/src/4.heredoc/heredoc_tmp_files.c
@@ -17,7 +17,7 @@ void	save_line_to_tmp_file(t_minishell *mshell, \
 		while (input[i])
 		{
 			if (input[i] == '$' && is_valid_char_expansion(input[i + 1]))
-				i += expand_content(mshell, &input[i], fd_tmp, NULL);
+				i += expand_content(mshell, NULL, &input[i], fd_tmp, NULL);
 			else if (input[i] == '$' && input[i + 1] == '$')
 				i += expand_pid(mshell, fd_tmp, NULL);
 			else if (input[i] == '$' && input[i + 1] == '?')

--- a/src/5.quotes_handle/quotes_handler.c
+++ b/src/5.quotes_handle/quotes_handler.c
@@ -34,7 +34,6 @@ static void	delete_token(t_input *input, t_token *current, t_token *previous)
 		input->tokens = current->next;
 	}
 }
-//this is to find out that it is expandable which has space AND is FILE_TOKEN. So that it would not be expanded
 static bool	is_ambiguous_redirect(t_minishell *mshell, t_token *current, char *str)
 {
 	size_t	i;
@@ -61,7 +60,13 @@ static bool	is_ambiguous_redirect(t_minishell *mshell, t_token *current, char *s
 				}
 				j++;
 			}
+			return (0);
 		}
+	}
+	if (env[i] == NULL)
+	{
+		current->ambiguous = 1;
+		return (1);
 	}
 	return (0);
 }

--- a/src/5.quotes_handle/quotes_handler.c
+++ b/src/5.quotes_handle/quotes_handler.c
@@ -8,13 +8,73 @@ static void	init_vars(size_t *i, char **input_str, \
 	*input_str = current->value;
 }
 
-static void	loop_through_word(t_minishell *mshell, t_token *current)
+static void	find_and_set_next_command(t_token *current)
+{
+	current = current->next;
+	while (current)
+	{
+		if (current->type == ARG)
+		{
+			current->type = COMMAND;
+			return ;
+		}
+		current = current->next;
+	}
+}
+
+static void	delete_token(t_input *input, t_token *current, t_token *previous)
+{
+	if (current->type == COMMAND)
+		find_and_set_next_command(current);
+	if (previous)
+		previous->next = current->next;
+	else
+	{
+		current->type = 0;
+		input->tokens = current->next;
+	}
+}
+//this is to find out that it is expandable which has space AND is FILE_TOKEN. So that it would not be expanded
+static bool	is_ambiguous_redirect(t_minishell *mshell, t_token *current, char *str)
+{
+	size_t	i;
+	size_t	j;
+	size_t	len;
+	char	**env;
+
+	if (current->type != FILE_TOKEN)
+		return (0);
+	env = mshell->envp->envp;
+	len = get_len_explandeble(str);
+	i = -1;
+	while (env[++i])
+	{
+		if (expandable_exists(len, env, i, str))
+		{
+			j = skip_to_start_of_expandable(env[i]);
+			while (env[i][j])
+			{
+				if (current && ft_isspace(env[i][j]))
+				{
+					current->ambiguous = 1;
+					return (1);
+				}
+				j++;
+			}
+		}
+	}
+	return (0);
+}
+
+static void	loop_through_word(t_minishell *mshell, t_input *input, t_token *current, t_token *previous)
 {
 	t_quotes_helper	quotes;
 	char			*new_str;
 	char			*input_str;
 	size_t			i;
+	bool			is_only_env_expandable;
 
+	is_only_env_expandable = 1;
 	init_vars(&i, &input_str, current, &quotes);
 	new_str = ft_arena_strdup(mshell->arena, "");
 	if (!new_str)
@@ -22,29 +82,48 @@ static void	loop_through_word(t_minishell *mshell, t_token *current)
 	while (input_str[i])
 	{
 		update_quote_state(input_str[i], &quotes);
-		if (is_valid_expandable(quotes, &input_str[i]))
-			i += expand_content(mshell, &input_str[i], 0, &new_str);
+		if (is_valid_expandable(quotes, &input_str[i]) && !is_ambiguous_redirect(mshell, current, &input_str[i]))
+			i += expand_content(mshell, current, &input_str[i], 0, &new_str);
 		else if (is_pid_expansion(quotes, &input_str[i]))
+		{
+			is_only_env_expandable = 0;
 			i += expand_pid(mshell, 0, &new_str);
+		}
 		else if (is_exitcode_expansion(quotes, &input_str[i]))
+		{
+			is_only_env_expandable = 0;
 			i += expand_exitcode_value(mshell, 0, &new_str);
+		}
 		else if (there_is_quote_state_change(quotes))
+		{
+			is_only_env_expandable = 0;
 			i++;
+		}
 		else
+		{
+			is_only_env_expandable = 0;
 			append_char(mshell, input_str, &new_str, i++);
+		}
 	}
-	replace_content_of_token(current, new_str);
+	if (new_str[0] == '\0' && is_only_env_expandable == 1 && (current->type == COMMAND || current->type == ARG))
+		delete_token(input, current, previous);
+	else
+		replace_content_of_token(current, new_str);
 }
 
-void	expand_remove_quotes(t_minishell *mshell, t_token *tokens)
+void	expand_remove_quotes(t_minishell *mshell, t_input *input)
 {
 	t_token	*current;
+	t_token	*previous;
 
-	current = tokens;
+	current = input->tokens;
+	previous = NULL;
 	while (current)
 	{
 		if (is_any_word(current->type))
-			loop_through_word(mshell, current);
+			loop_through_word(mshell, input, current, previous);
+		if (current->type != 0)
+			previous = current;
 		current = current->next;
 	}
 }

--- a/src/6.expansion/expansion.c
+++ b/src/6.expansion/expansion.c
@@ -49,7 +49,7 @@ size_t	expand_pid(t_minishell *mshell, int fd, char **new_str)
 	return (2);
 }
 
-size_t	expand_content(t_minishell *mshell, char *str, int fd, char **new_str)
+size_t	expand_content(t_minishell *mshell, t_token *current, char *str, int fd, char **new_str)
 {
 	size_t	i;
 	size_t	j;

--- a/src/7.ast/ast.c
+++ b/src/7.ast/ast.c
@@ -51,6 +51,8 @@ void	build_ast_binary_tree(t_minishell *mshell, t_token *tokens, t_ast **ast)
 	size_t	i;
 
 	*ast = NULL;
+	if (!tokens)
+		return ;
 	i = 0;
 	amount_of_pipes = get_amount_of_pipes(tokens);
 	while (i < amount_of_pipes)

--- a/src/8.execution/execution.c
+++ b/src/8.execution/execution.c
@@ -5,7 +5,8 @@ int	execute_in_sub_process(t_minishell *mshell, t_ast *ast);
 
 void execute_ast_v1(t_minishell *mshell, t_ast *ast)
 {
-
+	if (!ast)
+		return ;
 	if (ast->type != PIPE && is_builtin(ast))
 		mshell->exitcode = execute_builtin_alone(mshell, ast);
 	else

--- a/src/99.dev/print_development.c
+++ b/src/99.dev/print_development.c
@@ -25,7 +25,7 @@ void print_tokens(t_token *tokens)
 	{
 		if (tokens->value)
 		{
-			printf("Type: %15s, Length of token: %d, Value: %.*s\n", get_token_type_name(tokens->type), tokens->len, tokens->len, tokens->value);
+			printf("Type: %15s, Length of token: %d, Value: %.*s, Ambiguous %i\n", get_token_type_name(tokens->type), tokens->len, tokens->len, tokens->value, tokens->ambiguous);
 		}
 		tokens = tokens->next;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -29,8 +29,8 @@ int main(int ac, char **av, char **envp)
 			continue ;
 		if (handle_heredoc(&mshell, input.tokens) == FAIL)
 			continue ;
-		expand_remove_quotes(&mshell, input.tokens);
-		// print_tokens(input.tokens);
+		expand_remove_quotes(&mshell, &input);
+		print_tokens(input.tokens);
 		build_ast_binary_tree(&mshell, input.tokens, &ast);
 
 		//print_whole_tree(ast);

--- a/src/main.c
+++ b/src/main.c
@@ -30,7 +30,7 @@ int main(int ac, char **av, char **envp)
 		if (handle_heredoc(&mshell, input.tokens) == FAIL)
 			continue ;
 		expand_remove_quotes(&mshell, &input);
-		print_tokens(input.tokens);
+		// print_tokens(input.tokens);
 		build_ast_binary_tree(&mshell, input.tokens, &ast);
 
 		//print_whole_tree(ast);


### PR DESCRIPTION
Add handle of cases like: "$sasd echo a", it would ignore all nonexistent expansions
Add handle for "<$x" if x="a o" and <$asdasd. It would set ambiguous of that token to 1.